### PR TITLE
Fixed some bugs with the EmailLogger

### DIFF
--- a/Logging/Loggers/EmailLogger.cs
+++ b/Logging/Loggers/EmailLogger.cs
@@ -104,13 +104,12 @@ td { vertical-align: top; border-left: 1px solid #ccc; padding: 0 6px; }
         /// </summary>
         [NotNull]
         public static readonly FormatBuilder DefaultBodyHtml = new FormatBuilder()
+            .AppendLine($"<style>{DefaultBodyStyle}</style>")
             .AppendFormat(
                 /* language=HTML */
-                @"<style>{0}</style>
-{Logs:{<items>:{<item>:{html}}}{<join>:\r\n<hr/>\r\n}}
+                @"{Logs:{<items>:{<item>:{html}}}{<join>:
 <hr/>
-<p><span class=""Footer"">This email was automatically generated.</span><p>",
-                DefaultBodyStyle)
+}}<hr/><p><span class=""Footer"">This email was automatically generated.</span><p>")
             .MakeReadOnly();
 
         /// <summary>

--- a/Utilities/Converters/SecureStringConverter.cs
+++ b/Utilities/Converters/SecureStringConverter.cs
@@ -1,0 +1,68 @@
+﻿#region © Copyright Web Applications (UK) Ltd, 2017.  All rights reserved.
+// Copyright (c) 2017, Web Applications UK Ltd
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Web Applications UK Ltd nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL WEB APPLICATIONS UK LTD BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Security;
+
+namespace WebApplications.Utilities.Converters
+{
+    /// <summary>
+    /// Type converter for the <see cref="SecureString"/> class.
+    /// </summary>
+    /// <seealso cref="System.ComponentModel.TypeConverter" />
+    public class SecureStringConverter : TypeConverter
+    {
+        /// <summary>Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.</summary>
+        /// <returns>true if this converter can perform the conversion; otherwise, false.</returns>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context. </param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from. </param>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        /// <summary>Converts the given object to the type of this converter, using the specified context and culture information.</summary>
+        /// <returns>An <see cref="T:System.Object" /> that represents the converted value.</returns>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context. </param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture. </param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert. </param>
+        /// <exception cref="T:System.NotSupportedException">The conversion cannot be performed. </exception>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (!(value is string str)) return base.ConvertFrom(context, culture, value);
+
+            SecureString ss = new SecureString();
+            foreach (char ch in str)
+                ss.AppendChar(ch);
+            ss.MakeReadOnly();
+
+            return ss;
+        }
+    }
+}

--- a/Utilities/ModuleInitializer.cs
+++ b/Utilities/ModuleInitializer.cs
@@ -28,6 +28,7 @@
 using NodaTime;
 using System.ComponentModel;
 using System.Net.Mail;
+using System.Security;
 using System.Xml.Linq;
 using WebApplications.Utilities.Annotations;
 using WebApplications.Utilities.Converters;
@@ -61,6 +62,7 @@ namespace WebApplications.Utilities
             TypeDescriptor.AddAttributes(typeof(XNamespace), new TypeConverterAttribute(typeof(XNamespaceConverter)));
             TypeDescriptor.AddAttributes(typeof(MailAddress), new TypeConverterAttribute(typeof(MailAddressConverter)));
             TypeDescriptor.AddAttributes(typeof(MailAddressCollection), new TypeConverterAttribute(typeof(MailAddressCollectionConverter)));
+            TypeDescriptor.AddAttributes(typeof(SecureString), new TypeConverterAttribute(typeof(SecureStringConverter)));
         }
     }
 }

--- a/Utilities/WebApplications.Utilities.csproj
+++ b/Utilities/WebApplications.Utilities.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Converters\DateTimeZoneConverter.cs" />
     <Compile Include="Converters\MailAddressCollectionConverter.cs" />
     <Compile Include="Converters\MailAddressConverter.cs" />
+    <Compile Include="Converters\SecureStringConverter.cs" />
     <Compile Include="Converters\XNamespaceConverter.cs" />
     <Compile Include="Converters\DurationConverter.cs" />
     <Compile Include="Converters\InstantConverter.cs" />


### PR DESCRIPTION
The PR #48 included a couple of bugs. This PR fixes them.

- There was a TypeConverter for SecureString missing, preventing a password being specified in the .config
- The default body HTML format was invalid.