### PR TITLE
Move reference to Microsoft.SqlServer.Types to a package (resolves #58)

### DIFF
--- a/Testing/WebApplications.Testing.csproj
+++ b/Testing/WebApplications.Testing.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{E41CD12C-805C-4493-A45A-9BC917D7B240}</ProjectGuid>
@@ -8,7 +8,9 @@
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\Common.proj" />
   <ItemGroup>
-    <Reference Include="Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SqlServer.Types.11.0.2\lib\net20\Microsoft.SqlServer.Types.dll</HintPath>
+    </Reference>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>

--- a/Testing/WebApplications.Testing.vsdoc
+++ b/Testing/WebApplications.Testing.vsdoc
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <!--   VSdocman config file for current project/solution.-->
-  <activeProfile>default</activeProfile>
-  <appSettings>
-  </appSettings>
-</configuration>

--- a/Testing/packages.config
+++ b/Testing/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net452" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Use a NuGet package instead of relying on it being installed on the machine already, as newer SQL Server installs wouldn't bring this version with them.
Remove redundant vsdoc file, we now use DocFx.